### PR TITLE
ensure removeMark can pluck multiple matches from within a node

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -48,8 +48,13 @@ Transform.prototype.removeMark = function(from, to, mark = null) {
     step++
     let toRemove = null
     if (mark instanceof MarkType) {
-      let found = mark.isInSet(node.marks)
-      if (found) toRemove = [found]
+      const found = []
+      let set = node.marks
+      while (mark.isInSet(set)) {
+        found.push(mark.isInSet(set))
+        set = mark.removeFromSet(set)
+      }
+      if (found.length >= 1) toRemove = found
     } else if (mark) {
       if (mark.isInSet(node.marks)) toRemove = [mark]
     } else {

--- a/test/test-trans.js
+++ b/test/test-trans.js
@@ -106,6 +106,18 @@ describe("Transform", () => {
        rem(doc(p("<a>hello, ", em("this is ", strong("much"), " ", a("markup<b>")))),
            null,
            doc(p("<a>hello, this is much markup"))))
+
+    it("can remove more than one mark of the same type from a block", () => {
+      let schema = new Schema({
+         nodes: {doc: {content: "text*"},
+               text: {}},
+         marks: {comment: {excludes: "", attrs: {id: {}}}}
+      })
+      let tr = new Transform(schema.node("doc", null, schema.text("hi", [schema.mark("comment", {id: 1}), schema.mark("comment", {id: 2})])))
+      ist(tr.doc.firstChild.marks.length, 2)
+      tr.removeMark(0, 2, schema.marks["comment"])
+      ist(tr.doc.firstChild.marks.length, 0)
+    })
   })
 
   describe("insert", () => {


### PR DESCRIPTION
hi there! 👋 

currently `removeMark(from, to, MarkType)` only removes the first match it encounters within each block. this change aligns the behavior with the documentation and removes them all instead.